### PR TITLE
Resolves #29

### DIFF
--- a/R/latex.R
+++ b/R/latex.R
@@ -132,11 +132,18 @@ latexmk_emu = function(
 
   pkgs_last = character()
   filep = paste0(base, '.pdf')
-  # backup the PDF output if it exists, and move it back if the compilation failed
+  # If PDF output exists, then temporarily move it out of the way.
+  # Upon successful compilation, the existing PDF will be copied over 
+  # before moving back.
   if (file.exists(filep)) {
-    filep2 = tempfile('tinytex_', '.', '.pdf')
-    if (file.rename(filep, filep2)) on.exit(
-      if (file.exists(filep)) file.remove(filep2) else file.rename(filep2, filep),
+    filep_existing = tempfile('tinytex_', '.', '.pdf')
+    if (file.rename(filep, filep_existing)) on.exit({      
+        if (file.exists(filep)) {
+          file.copy(filep, filep_existing, overwrite = TRUE)
+          file.remove(filep)
+        }
+        file.rename(filep_existing, filep)
+      }, 
       add = TRUE
     ) else warning(
       'It seems I do not have write permission to the directory "', getwd(), '"',


### PR DESCRIPTION
This resolves #29 in a minimally intrusive way.  Rather than trying to change the output filename using the `-jobname` argument to the latex engine, this PR modifies the file renaming logic and exit hook.

1. An existing PDF file will be renamed temporarily.
2. Upon successful compilation, the new PDF will be copied on top of the existing PDF (with the temporary name) and removed.
3. The PDF (existing or new) is renamed back.

These steps help external viewers detect changes to the PDF, because they will (hopefully) see that the PDF has been overwritten rather than just moved away.