### PR TITLE
Add tinytex documentation website url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Description: Helper functions to install and maintain the 'LaTeX' distribution
 Imports: xfun (>= 0.5)
 Suggests: testit, rstudioapi
 License: MIT + file LICENSE
-URL: https://github.com/yihui/tinytex
+URL: https://github.com/yihui/tinytex, https://yihui.name/tinytex/
 BugReports: https://github.com/yihui/tinytex/issues
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
it would make the documentation website url visible from cran page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yihui/tinytex/119)
<!-- Reviewable:end -->
