### PR TITLE
Package updates

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -19,7 +19,6 @@ eso-pic
 eurosym
 extsizes
 fancyhdr
-float
 floatrow
 fontaxes
 hardwrap
@@ -31,7 +30,7 @@ lipsum
 listings
 ltxkeys
 ly1
-mathalfa
+mathalpha
 mathpazo
 mathtools
 mdframed


### PR DESCRIPTION
The `float` package was already included in the `pkgs-custom` with PR#123.

---

> Pack­age `math­alfa` was re­named to `math­al­pha`. For back­ward com­pat­i­bil­ity the old name will con­tinue to be rec­og­nized in LaTeX doc­u­ments.
>
> <https://ctan.org/pkg/mathalpha>

Currently, it produces an error `tlmgr.pl install: package mathalfa not present in repository`