### PR TITLE
change domain for website yihui.name to yihui.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ env:
     - R_PKG="$(basename $TRAVIS_REPO_SLUG)"
 
 repos:
-  XRAN: https://xran.yihui.name
+  XRAN: https://xran.yihui.org
 
 before_install:
-  - "curl https://xran.yihui.name/.gitconfig -o ~/.gitconfig"
+  - "curl https://xran.yihui.org/.gitconfig -o ~/.gitconfig"
   - Rscript -e 'if (!require("covr")) install.packages("covr")'
 
 after_success:
   - Rscript -e 'covr::codecov()'
-  - "(curl https://xran.yihui.name/r-xran | bash)"
+  - "(curl https://xran.yihui.org/r-xran | bash)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ repos:
   XRAN: https://xran.yihui.org
 
 before_install:
-  - "curl https://xran.yihui.org/.gitconfig -o ~/.gitconfig"
+  - "curl -L https://xran.yihui.org/.gitconfig -o ~/.gitconfig"
   - Rscript -e 'if (!require("covr")) install.packages("covr")'
 
 after_success:
   - Rscript -e 'covr::codecov()'
-  - "(curl https://xran.yihui.org/r-xran | bash)"
+  - "(curl -L https://xran.yihui.org/r-xran | bash)"


### PR DESCRIPTION
Following https://github.com/rstudio/pagedown/issues/154 this changes the domain of the website in `travis.yml` where redirection are not handled by curl currently

@yihui should we change also anywhere in the source code ?
Tinytex has some installation scripts that use this website. `wget` seem to follow by default and powershell also. Other curl commands have `-L` option already. 

Do you want to handle only with redirection ?
I am thinking it could be better to replace all