### PR TITLE
titling is no longer required for R Markdown documents

### DIFF
--- a/tools/pkgs-custom.txt
+++ b/tools/pkgs-custom.txt
@@ -34,7 +34,6 @@ oberdiek
 pdftexcmds
 tex
 times
-titling
 tools
 upquote
 url


### PR DESCRIPTION
after the commit https://github.com/rstudio/rmarkdown/commit/cf8e5df1b309edc9d75e610f9c52c451588c302b

Do not merge until the next version of rmarkdown is on CRAN.