### PR TITLE
Add bitset to pkgs-custom. #158

### DIFF
--- a/tools/pkgs-custom.txt
+++ b/tools/pkgs-custom.txt
@@ -4,6 +4,7 @@ amsmath
 atbegshi
 atveryend
 bibtex
+bitset
 booktabs
 caption
 dvipdfmx


### PR DESCRIPTION
Adds `bitset` package to `pkgs-custom.txt`. `bitset` was originally part of `oberdiek` but has been moved to its own package (https://github.com/ho-tex/oberdiek/commit/f10f049c8ad33d225b507539c69e9e13780234cf).

Error on GH Actions here: https://github.com/bcgov/bcdata/runs/344502843#step:10:112

```r
> tinytex::parse_packages(text = "! LaTeX Error: File `bitset.sty' not found")
tlmgr search --file --global '/bitset.sty'
[1] "bitset"
```
