### PR TITLE
Handle missing "hyphen-" package

### DIFF
--- a/R/latex.R
+++ b/R/latex.R
@@ -493,6 +493,7 @@ detect_files = function(text) {
   # ! xdvipdfmx:fatal: pdf_ref_obj(): passed invalid object.
   # ! Package tikz Error: I did not find the tikz library 'hobby'... named tikzlibraryhobby.code.tex
   # support file `supp-pdf.mkii' (supp-pdf.tex) is missing
+  # ! I can't find file `hyph-de-1901.ec.tex'.
   r = c(
     ".*! Font [^=]+=([^ ]+).+ not loadable.*",
     '.*! .*The font "([^"]+)" cannot be found.*',
@@ -512,7 +513,8 @@ detect_files = function(text) {
     '.* \\(file ([^)]+)\\): cannot open .*',
     ".*file `([^']+)' .*is missing.*",
     ".*! CTeX fontset `([^']+)' is unavailable.*",
-    ".*: ([^:]+): command not found.*"
+    ".*: ([^:]+): command not found.*",
+    ".*! I can't find file `([^']+)'.*"
   )
   x = grep(paste(r, collapse = '|'), text, value = TRUE)
   if (length(x) > 0) unique(unlist(lapply(r, function(p) {

--- a/tests/test-cran/test-latex.R
+++ b/tests/test-cran/test-latex.R
@@ -24,4 +24,6 @@ assert('detect_files() can detect filenames from LaTeX log', {
   (detect_files('! Package isodate.sty Error: Package file substr.sty not found.') %==% 'substr.sty')
 
   (detect_files("! Package fontenc Error: Encoding file `t2aenc.def' not found.") %==% 't2aenc.def')
+
+  (detect_files("! I can't find file `hyph-de-1901.ec.tex'.") %==% 'hyph-de-1901.ec.tex')
 })


### PR DESCRIPTION
I hit this new format of error when building rmarkdown-cookbook on fresh installed tinytex with TeX Live 2020.

```
Local configuration file hyphen.cfg used
===========================================
(/home/songl/.TinyTeX/texmf-dist/tex/generic/babel/hyphen.cfg
(/home/songl/.TinyTeX/texmf-dist/tex/generic/babel/switch.def)
(/home/songl/.TinyTeX/texmf-dist/tex/generic/hyphen/hyphen.tex)
(/home/songl/.TinyTeX/texmf-dist/tex/generic/hyphen/dumyhyph.tex)
(/home/songl/.TinyTeX/texmf-dist/tex/generic/hyphen/zerohyph.tex)
(/home/songl/.TinyTeX/texmf-dist/tex/generic/dehyph-exptl/dehypht-x-2019-04-04.
tex
dehyph-exptl: using pTeX engine. Loading patterns provided by package hyph-utf8
.
! I can't find file `hyph-de-1901.ec.tex'.
l.126   \input hyph-de-1901.ec.tex
```
