### PR TITLE
Add polyglossia to pkgs-yihui.txt for language support with XeTeX

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -55,6 +55,7 @@ pdflscape
 pdfpages
 pgf
 picinpar
+polyglossia
 preprint
 preview
 psnfss


### PR DESCRIPTION
When setting the metadata variable `lang` and `latex_engine: xelatex` in a R Markdown file, `polyglossia` is being required by default. Including `polyglossia` in `pkgs-yihui.txt` would ensure that a tinytex installation via `tinytex:::install_prebuilt()` would work here.