### PR TITLE
Make tinytex usable on Unix-alikes like FreeBSD again

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -210,7 +210,7 @@ win_app_dir = function(..., error = TRUE) {
   file.path(d, ...)
 }
 
-os_index = if (is_windows()) 1 else if (is_unix()) 2 else if (is_macos()) 3 else 0
+os_index = if (is_windows()) 1 else if (is_macos()) 3 else if (is_unix()) 2 else 0
 
 default_inst = function() switch(
   os_index, win_app_dir('TinyTeX'), '~/.TinyTeX', '~/Library/TinyTeX'


### PR DESCRIPTION
Since v0.24, install.R does not recognize FreeBSD for os_index any more. The patch should bring back this behaviour.

I had no possibility to test is_unix() with Linux and MacOS. While the first should work out of the box, the second has to return digit 3 as before?