### PR TITLE
show warning on.exit unless option is set to FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tinytex
 Type: Package
 Title: Helper Functions to Install and Maintain TeX Live, and Compile LaTeX Documents
-Version: 0.27.1
+Version: 0.27.2
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person(family = "RStudio, PBC", role = "cph"),

--- a/R/latex.R
+++ b/R/latex.R
@@ -13,6 +13,9 @@
 #' engine a number of times (the maximum is 10 by default) to resolve all
 #' cross-references.
 #'
+#' By default, LaTeX warnings will be converted to R warnings. To suppress these
+#' warnings, set \code{options(tinytex.latexmk.warning = FALSE)}.
+#'
 #' If \code{emulation = FALSE}, you need to make sure the executable
 #' \command{latexmk} is available in your system, otherwise \code{latexmk()}
 #' will fall back to \code{emulation = TRUE}. You can set the global option
@@ -170,7 +173,7 @@ latexmk_emu = function(
   on.exit({
     files2 = exist_files(aux_files)
     files3 = setdiff(files2, files1)
-    if (keep_log || length(latex_warning(logfile, TRUE))) files3 = setdiff(files3, logfile)
+    if (keep_log || length(latex_warning(logfile))) files3 = setdiff(files3, logfile)
     if (clean) unlink(files3)
     .global$update_noted = NULL
   }, add = TRUE)
@@ -373,7 +376,7 @@ check_unicode = function(x) {
 }
 
 # whether a LaTeX log file contains LaTeX or package (e.g. babel) warnings
-latex_warning = function(file, show = FALSE) {
+latex_warning = function(file, show = getOption('tinytex.latexmk.warning', TRUE)) {
   if (!file.exists(file)) return()
   x = readLines(file, warn = FALSE)
   if (length(i <- grep('^(LaTeX|Package [[:alnum:]]+) Warning:', x)) == 0) return()
@@ -393,7 +396,7 @@ latex_warning = function(file, show = FALSE) {
 
 # check if any babel packages are missing
 check_babel = function(file) {
-  if (length(m <- latex_warning(file)) == 0 || length(grep('^Package babel Warning:', m)) == 0)
+  if (length(m <- latex_warning(file, FALSE)) == 0 || length(grep('^Package babel Warning:', m)) == 0)
     return()
   r = "^\\(babel).* language `([[:alpha:]]+)'.*$"
   if (length(m <- grep_sub(r, '\\1', m)) == 0) return()

--- a/man/latexmk.Rd
+++ b/man/latexmk.Rd
@@ -82,6 +82,9 @@ necessary (the \file{*.idx} file exists), run the bibliography engine
 engine a number of times (the maximum is 10 by default) to resolve all
 cross-references.
 
+By default, LaTeX warnings will be converted to R warnings. To suppress these
+warnings, set \code{options(tinytex.latexmk.warning = FALSE)}.
+
 If \code{emulation = FALSE}, you need to make sure the executable
 \command{latexmk} is available in your system, otherwise \code{latexmk()}
 will fall back to \code{emulation = TRUE}. You can set the global option


### PR DESCRIPTION
This will close #256 

`latex_warning` default to FALSE
https://github.com/yihui/tinytex/blob/e1b43e503642bde86f00ec6428eb7f2e0faca566/R/latex.R#L376

I could add the option in there but it currently is used in two places
1. Sets to TRUE here: this is where we want to suppress the output
https://github.com/yihui/tinytex/blob/5199a89d0d7c01b166eb7dced1b117c67b569774/R/latex.R#L173

1. set to FALSE here (the default of `latex_warning`)
https://github.com/yihui/tinytex/blob/5199a89d0d7c01b166eb7dced1b117c67b569774/R/latex.R#L395-L396

I am not sure we want to change the default and it prints warning in the second case. 

I could do 
```r
latex_warning = function(file, show = getOption("tinytex.latexmk.warning", FALSE)) {
```

but with 1., it is set to TRUE so the option would not be taken into account. 

We could do 
```r
latex_warning = function(file, show = getOption("tinytex.latexmk.warning", TRUE)) {
```
and in that case we should set to FALSE in second usage, 2. above.

This is the other preferred solution but this would change the current default. 
@yihui do you prefer this ? 

We could also do 
```r
if (missing(show)) show = getOption("tinytex.latexmk.warning", show)
```
inside the function, but then we would also have to change the current argument option
* use default in usage 1. 
* Set to FALSE in usage 2.


Is this ok where I put it or do you prefer the `getOption` in `show` argument inside the `latex_warning` function. 

Thanks. 