### PR TITLE
change regex to find fonts 

### DIFF
--- a/R/latex.R
+++ b/R/latex.R
@@ -568,7 +568,7 @@ miss_font = function() {
 
 font_ext = function(x) {
   i = !grepl('[.]', x)
-  x[i] = paste0(x[i], '[.](tfm|afm|mf|otf)')
+  x[i] = paste0(x[i], '(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)')
   x
 }
 

--- a/tests/test-cran/test-latex.R
+++ b/tests/test-cran/test-latex.R
@@ -7,11 +7,11 @@ assert('detect_files() can detect filenames from LaTeX log', {
 
   (detect_files("/usr/local/bin/mktexpk: line 123: mf: command not found") %==% 'mf')
 
-  (grepl('^psyr\\[\\.\\]', detect_files("! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found")))
+  (detect_files("! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found") %==% font_ext("psyr"))
 
-  (grepl('^FandolSong-Regular\\[\\.\\]', detect_files('! The font "FandolSong-Regular" cannot be found.')))
+  (detect_files('! The font "FandolSong-Regular" cannot be found.') %==% font_ext("FandolSong-Regular"))
 
-  (grepl('^tcrm0700\\[\\.\\]', detect_files('!pdfTeX error: /usr/local/bin/pdflatex (file tcrm0700): Font tcrm0700 at 600 not found')))
+  (detect_files('!pdfTeX error: /usr/local/bin/pdflatex (file tcrm0700): Font tcrm0700 at 600 not found') %==% font_ext('tcrm0700'))
 
   (detect_files("or the language definition file ngerman.ldf was not found") %==% 'ngerman.ldf')
 

--- a/tests/test-cran/test-latex.R
+++ b/tests/test-cran/test-latex.R
@@ -1,29 +1,19 @@
 library(testit)
 
 assert('detect_files() can detect filenames from LaTeX log', {
-  (length(detect_files("asdf qwer")) == 0)
-
-  (detect_files("! LaTeX Error: File `framed.sty' not found.") %==% 'framed.sty')
-
-  (detect_files("/usr/local/bin/mktexpk: line 123: mf: command not found") %==% 'mf')
-
+  # Fonts are tested in test-tlmgr.R also
   (detect_files("! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found") %==% font_ext("psyr"))
-
   (detect_files('! The font "FandolSong-Regular" cannot be found.') %==% font_ext("FandolSong-Regular"))
-
   (detect_files('!pdfTeX error: /usr/local/bin/pdflatex (file tcrm0700): Font tcrm0700 at 600 not found') %==% font_ext('tcrm0700'))
 
+  (length(detect_files("asdf qwer")) == 0)
+  (detect_files("! LaTeX Error: File `framed.sty' not found.") %==% 'framed.sty')
+  (detect_files("/usr/local/bin/mktexpk: line 123: mf: command not found") %==% 'mf')
   (detect_files("or the language definition file ngerman.ldf was not found") %==% 'ngerman.ldf')
-
   (detect_files("!pdfTeX error: pdflatex (file 8r.enc): cannot open encoding file for reading") %==% '8r.enc')
-
   (detect_files("! CTeX fontset `fandol' is unavailable in current mode") %==% 'fandol')
-
   (detect_files('Package widetext error: Install the flushend package which is a part of sttools') %==% 'flushend.sty')
-
   (detect_files('! Package isodate.sty Error: Package file substr.sty not found.') %==% 'substr.sty')
-
   (detect_files("! Package fontenc Error: Encoding file `t2aenc.def' not found.") %==% 't2aenc.def')
-
   (detect_files("! I can't find file `hyph-de-1901.ec.tex'.") %==% 'hyph-de-1901.ec.tex')
 })

--- a/tests/test-travis/test-tlmgr.R
+++ b/tests/test-travis/test-tlmgr.R
@@ -17,9 +17,10 @@ assert('`tlmgr info` can list the installed packages', {
   (c('xetex', 'luatex', 'graphics') %in% res)
 })
 
-suppressMessages(
-  assert('fonts package are correctly identified', {
-    parse_packages(text = "! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found") %==% "symbol"
-    parse_packages(text = '! Package fontspec Error: The font "Caladea" cannot be found.') %==% 'caladea'
-  })
-)
+assert('fonts package are correctly identified', {
+  p_q <- function(...) parse_packages(..., quiet = c(TRUE, TRUE, TRUE))
+  (p_q(text = "! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found") %==% 'symbol')
+  (p_q(text = '! The font "FandolSong-Regular" cannot be found.') %==% 'fandol')
+  (p_q(text = '!pdfTeX error: /usr/local/bin/pdflatex (file tcrm0700): Font tcrm0700 at 600 not found') %==% 'ec')
+  (p_q(text = '! Package fontspec Error: The font "Caladea" cannot be found.') %==% 'caladea')
+})

--- a/tests/test-travis/test-tlmgr.R
+++ b/tests/test-travis/test-tlmgr.R
@@ -16,3 +16,10 @@ assert('`tlmgr info` can list the installed packages', {
   # only check a few basic packages
   (c('xetex', 'luatex', 'graphics') %in% res)
 })
+
+suppressMessages(
+  assert('fonts package are correctly identified', {
+    parse_packages(text = "! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found") %==% "symbol"
+    parse_packages(text = '! Package fontspec Error: The font "Caladea" cannot be found.') %==% 'caladea'
+  })
+)


### PR DESCRIPTION
This will fix #267 by using a more generic regex, and adding one extension. 

The issue in https://github.com/rstudio/rticles/pull/362#pullrequestreview-570641514 should also be fixed now.

I open the PR so that you check the regex in case I missed some edge case.

I added some tests for the CI so that we are sure a font is found in the database. But the **rticle** CI is also a way to test that for some formats

