### PR TITLE
Retry download with Powershell if it has error

### DIFF
--- a/tools/install-bin-windows.bat
+++ b/tools/install-bin-windows.bat
@@ -15,8 +15,23 @@ if not defined TINYTEX_VERSION (
   set TINYTEX_URL=https://github.com/yihui/tinytex-releases/releases/download/v%TINYTEX_VERSION%/%TINYTEX_INSTALLER%-v%TINYTEX_VERSION%.zip
 )
 
-rem download the zip package and unzip it
-powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest $Env:TINYTEX_URL -OutFile install.zip"
+rem download the zip package - retry 5 times if issues
+set /a retry=0
+:download
+if %retry% leq 5 (
+  powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest $Env:TINYTEX_URL -OutFile install.zip"
+  if errorlevel 1 (
+    echo Retrying download... attempt %retry%
+    set /a retry+=1
+    goto download
+  )
+  echo Download succeeded
+) else (
+  echo TinyTeX zip installer not downloaded
+  goto :exit
+)
+
+rem unzip it
 powershell -Command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('install.zip', '.'); }"
 del install.zip
 
@@ -27,3 +42,6 @@ move /y TinyTeX "%APPDATA%"
 call "%APPDATA%\TinyTeX\bin\win32\tlmgr" path add
 
 pause
+
+:exit
+exit /b %ERRORLEVEL%

--- a/tools/install-bin-windows.bat
+++ b/tools/install-bin-windows.bat
@@ -33,6 +33,11 @@ if %retry% leq 5 (
 
 rem unzip it
 powershell -Command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('install.zip', '.'); }"
+if errorlevel 1 (
+  if exist install.zip del install.zip
+  echo unzipping did not worked
+  goto exit
+)
 del install.zip
 
 rd /s /q "%APPDATA%\TinyTeX"

--- a/tools/install-bin-windows.bat
+++ b/tools/install-bin-windows.bat
@@ -28,7 +28,7 @@ if %retry% leq 5 (
   echo Download succeeded
 ) else (
   echo TinyTeX zip installer not downloaded
-  goto :exit
+  goto exit
 )
 
 rem unzip it


### PR DESCRIPTION
This PR tries to solve #270 by adding a retry mechanism if download fails. 

This is done in BAT by looking at the error code and retrying 5 times if there is an issue. 
If it does not work, it will also error properly, which is not the case now. 

the `powershell` code will indeed error, but the current `bat` file does not handle this error, and I believe that is why the `setup-tinytex` action does not properly error. (https://github.com/r-lib/actions/issues/213)
The action does [correctly try-catch](https://github.com/r-lib/actions/blob/a76196994633e92987350cb0bce04050a89d3f50/setup-tinytex/src/setup-tinytex.ts#L117) but our BAT file does not send an error from the powershell command. 

Is the `pause` command important also ? 
https://github.com/yihui/tinytex/blob/82e76dc7ac955cc7e160d80a4c97086ea4117d4f/tools/install-bin-windows.bat#L29

I have tested this locally and it works for me. I did not yet tested in on GHA. 

@yihui does it seem ok to you ? Merging will impact everyone using this script so I prefer having a second pair of eye on this. Thanks! 


Also a related question: is there a specific reason to have use `Invoke-WebRequest` ? 

It seems it is not the only method and not the best, one of the cons being (source is a bit old but still)
> Cons
Speed. This cmdlet is slow. From what I have observed, the HTTP response stream is buffered into memory. Once the file has been fully loaded, it is flushed to disk. This adds a huge performance hit and potential memory issues for large files.

Source: https://blog.jourdant.me/post/3-ways-to-download-files-with-powershell

We could try also this one: 
```powershell
powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;(New-Object System.Net.WebClient).DownloadFile($Env:TINYTEX_URL, 'install.zip')"
```

This works well. [doc](https://docs.microsoft.com/en-us/dotnet/api/system.net.webclient) says that now [`System.Net.Http.HttpClient class`](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient) but it could be too recent for being supporting in Powershell 5 by default. Did not try yet. 

I am wondering all that because having a powershell install script could be intesting. 