### PR TITLE
Try 3 download methods and returns the correct exit code

### DIFF
--- a/tools/install-bin-windows.bat
+++ b/tools/install-bin-windows.bat
@@ -32,13 +32,16 @@ if errorlevel 1 exit /b %ERRORLEVEL%
 
 :unzip
 rem unzip the downloaded file
+echo unzip TinyTeX
 powershell -Command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('install.zip', '.'); }"
 del install.zip
 
+echo Move to APPDATA folder
 rd /s /q "%APPDATA%\TinyTeX"
 rd /s /q "%APPDATA%\TinyTeX"
 move /y TinyTeX "%APPDATA%"
 
+echo add tlmgr to PATH
 call "%APPDATA%\TinyTeX\bin\win32\tlmgr" path add
 
 exit /b %ERRORLEVEL%

--- a/tools/install-bin-windows.bat
+++ b/tools/install-bin-windows.bat
@@ -15,8 +15,23 @@ if not defined TINYTEX_VERSION (
   set TINYTEX_URL=https://github.com/yihui/tinytex-releases/releases/download/v%TINYTEX_VERSION%/%TINYTEX_INSTALLER%-v%TINYTEX_VERSION%.zip
 )
 
-rem download the zip package and unzip it
+rem download the zip package - method 1
+echo Download zip file... Method 1
+powershell -Command "& { try {Add-Type -A 'System.Net.Http'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;$response = (New-Object System.Net.Http.HttpClient).GetAsync($Env:TINYTEX_URL); $response.Wait(); $outputFileStream = [System.IO.FileStream]::new('install.zip', [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write); $response.Result.Content.CopyToAsync($outputFileStream).Wait(); $outputFileStream.Close()} catch {throw $_}}"
+if ,not errorlevel 1 goto unzip
+
+rem Try another method if the first one failed
+echo Download zip file... Method 2
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;(New-Object System.Net.WebClient).DownloadFile($Env:TINYTEX_URL, 'install.zip')"
+if not errorlevel 1 goto :unzip
+
+rem Try last method
+echo Download zip file... Method 3
 powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest $Env:TINYTEX_URL -OutFile install.zip"
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+:unzip
+rem unzip the downloaded file
 powershell -Command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('install.zip', '.'); }"
 del install.zip
 
@@ -26,4 +41,4 @@ move /y TinyTeX "%APPDATA%"
 
 call "%APPDATA%\TinyTeX\bin\win32\tlmgr" path add
 
-pause
+exit /b %ERRORLEVEL%

--- a/tools/install-bin-windows.bat
+++ b/tools/install-bin-windows.bat
@@ -17,13 +17,13 @@ if not defined TINYTEX_VERSION (
 
 rem download the zip package - method 1
 echo Download zip file... Method 1
-powershell -Command "& { try {Add-Type -A 'System.Net.Http'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;$response = (New-Object System.Net.Http.HttpClient).GetAsync($Env:TINYTEX_URL); $response.Wait(); $outputFileStream = [System.IO.FileStream]::new('install.zip', [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write); $response.Result.Content.CopyToAsync($outputFileStream).Wait(); $outputFileStream.Close()} catch {throw $_}}"
-if ,not errorlevel 1 goto unzip
+powershell -Command "& { try {Add-Type -A 'System.Net.Http'; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $response = (New-Object System.Net.Http.HttpClient).GetAsync($Env:TINYTEX_URL); $response.Wait(); $outputFileStream = [System.IO.FileStream]::new('install.zip', [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write); $response.Result.Content.CopyToAsync($outputFileStream).Wait(); $outputFileStream.Close()} catch {throw $_}}"
+if not errorlevel 1 goto unzip
 
 rem Try another method if the first one failed
 echo Download zip file... Method 2
-powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;(New-Object System.Net.WebClient).DownloadFile($Env:TINYTEX_URL, 'install.zip')"
-if not errorlevel 1 goto :unzip
+powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile($Env:TINYTEX_URL, 'install.zip')"
+if not errorlevel 1 goto unzip
 
 rem Try last method
 echo Download zip file... Method 3


### PR DESCRIPTION
This PR is an alternative to #273. 

Instead of retrying the same download method, we are trying 3 methods :

1. Using the new class `System.Net.Http` 
2. Using the previous class `System.NetWebClient`
3. Using the cmdLet `Invoke-WebRequest`

Those three are described in https://adamtheautomator.com/powershell-download-file/

We are trying method in this order in Powershell using a try-catch to catch any error happening with one of the command sent to powershell so that we get a failed exit code in BAT. If one method succeed, we continue by unzipping. If none succeed with exit the BAT script with the error exit code so that it is catched by any other tool calling this script (like _r-lib/actions_)

What do you think of this compare to the retry solution ? 

It seems better than testing the powershell version because I can't find with which versions each method is supposed to work or not. 
