### PR TITLE
Also rerun when biblatex needs it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,9 @@ Version: 0.30.1
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person(family = "RStudio, PBC", role = "cph"),
-  person("Fernando", "Cagua", role = "ctb"),
+  person("Christophe", "Dervieux", role = "ctb", comment = c(ORCID = "0000-0003-4474-2498")),
   person("Ethan", "Heinzen", role = "ctb"),
+  person("Fernando", "Cagua", role = "ctb"),
   person()
   )
 Description: Helper functions to install and maintain the 'LaTeX' distribution

--- a/R/latex.R
+++ b/R/latex.R
@@ -290,9 +290,9 @@ tweak_aux = function(aux, x = readLines(aux)) {
   writeLines(x, aux)
 }
 
-needs_rerun = function(log) {
+needs_rerun = function(log, text = xfun::read_utf8(log)) {
   any(grepl(
-    '(Rerun to get |Please \\(re\\)run | Rerun LaTeX\\.)', readLines(log),
+    '(Rerun to get |Please \\(?re\\)?run | Rerun LaTeX\\.)', text,
     useBytes = TRUE
   ))
 }

--- a/tests/test-cran/test-latex.R
+++ b/tests/test-cran/test-latex.R
@@ -17,3 +17,11 @@ assert('detect_files() can detect filenames from LaTeX log', {
   (detect_files("! Package fontenc Error: Encoding file `t2aenc.def' not found.") %==% 't2aenc.def')
   (detect_files("! I can't find file `hyph-de-1901.ec.tex'.") %==% 'hyph-de-1901.ec.tex')
 })
+
+
+assert('rerun are correctly detected', {
+  (needs_rerun(text = "Package biblatex Warning: Please rerun LaTeX."))
+  (needs_rerun(text = "Please (re)run the file"))
+  (needs_rerun(text = "error: Rerun LaTeX."))
+  (needs_rerun(text = "Rerun to get the final file"))
+})


### PR DESCRIPTION
fixes rstudio/bookdown#1104 where the log contains
`Package biblatex Warning: Please rerun LaTeX.` when biblatex is used

it took me a while to find why this warning, but I think this is the cause. This will trigger the last rerun that will remove the warning has the log file won't have this log message anymore.