### PR TITLE
Support tectonic as a new engine

### DIFF
--- a/R/latex.R
+++ b/R/latex.R
@@ -116,30 +116,29 @@ latexmk = function(
     file_rename(pdf, pdf_file)
     pdf_file
   }
-  if (engine != "tectonic") {
-    if (emulation) {
-      latexmk_emu(
-        file, engine, bib_engine, engine_args, min_times, max_times,
-        install_packages, clean
-      )
-      return(check_pdf())
-    }
-    system2_quiet('latexmk', c(
-      '-latexoption=-halt-on-error -interaction=batchmode',
-      if (is_latex) '-latex=latex' else paste0('-pdf -pdflatex=', engine),
-      engine_args, shQuote(file)
-    ), error = {
-      if (install_packages) warning(
-        'latexmk(install_packages = TRUE) does not work when emulation = FALSE'
-      )
-      check_latexmk_version()
-    })
-    if (clean) system2('latexmk', c('-c', engine_args), stdout = FALSE)
-    check_pdf()
-  } else {
+  if (engine == 'tectonic') {
     system2_quiet('tectonic', c(engine_args, shQuote(file)))
     return(check_pdf())
   }
+  if (emulation) {
+    latexmk_emu(
+      file, engine, bib_engine, engine_args, min_times, max_times,
+      install_packages, clean
+    )
+    return(check_pdf())
+  }
+  system2_quiet('latexmk', c(
+    '-latexoption=-halt-on-error -interaction=batchmode',
+    if (is_latex) '-latex=latex' else paste0('-pdf -pdflatex=', engine),
+    engine_args, shQuote(file)
+  ), error = {
+    if (install_packages) warning(
+      'latexmk(install_packages = TRUE) does not work when emulation = FALSE'
+    )
+    check_latexmk_version()
+  })
+  if (clean) system2('latexmk', c('-c', engine_args), stdout = FALSE)
+  check_pdf()
 }
 
 #' @param ... Arguments to be passed to \code{latexmk()} (other than

--- a/man/latexmk.Rd
+++ b/man/latexmk.Rd
@@ -9,7 +9,7 @@
 \usage{
 latexmk(
   file,
-  engine = c("pdflatex", "xelatex", "lualatex", "latex"),
+  engine = c("pdflatex", "xelatex", "lualatex", "latex", "tectonic"),
   bib_engine = c("bibtex", "biber"),
   engine_args = NULL,
   emulation = TRUE,

--- a/man/latexmk.Rd
+++ b/man/latexmk.Rd
@@ -39,7 +39,8 @@ lualatex(...)
 be set in the global option \code{tinytex.engine_args}, e.g.,
 \code{options(tinytex.engine_args = '-shell-escape'}).}
 
-\item{emulation}{Whether to emulate the executable \command{latexmk} using R.}
+\item{emulation}{Whether to emulate the executable \command{latexmk} using R.
+Note that this is unused when \code{engine == 'tectonic'}.}
 
 \item{min_times, max_times}{The minimum and maximum number of times to rerun
 the LaTeX engine when using emulation. You can set the global options


### PR DESCRIPTION
This is a very simple set of changes that add support for tectonic when using `latexmk()`. In effect, that simply runs `tectonic` on the input tex file. This seems to work well locally. I'm not sure what sort of automated tests you want, so I haven't added anything.