### PR TITLE
  BugFix: Setting TINYTEX_VERSION  breaks the script

### DIFF
--- a/tools/install-bin-unix.sh
+++ b/tools/install-bin-unix.sh
@@ -47,7 +47,7 @@ else if [ $TINYTEX_INSTALLER != 'installer-unix' ]; then
   else
     echo "We do not have a prebuilt TinyTeX package for this operating system ${OSTYPE}."
     echo "I will try to install from source for you instead."
-    wget ${TINYTEX_URL}.tar.gz
+    wget -O ${TINYTEX_INSTALLER}.tar.gz ${TINYTEX_URL}.tar.gz
     tar xzf ${TINYTEX_INSTALLER}.tar.gz
     ./install.sh
     mkdir -p $TEXDIR


### PR DESCRIPTION
If you set the TINYTEX_VERSION the file download is named based on the version. The rest of the script assumes that it will be named without the version. This tells wget to download it as the generic name instead of the version specific name. 