### PR TITLE
Add AwesomeBox and FontAwesome

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -8,6 +8,7 @@ ametsoc
 amscls
 apacite
 appendix
+awesomebox
 babel-english
 babel-french
 bbm-macros
@@ -52,6 +53,7 @@ fancyhdr
 floatflt
 floatrow
 fmtcount
+fontawesome5
 fontaxes
 footmisc
 forarray


### PR DESCRIPTION
We are using AwesomeBox to support admonitions in Latex output and would love to have it supported in TinyTex to avoid the initial download on first pdf compile (and it depends upon FontAwesome). 