### PR TITLE
Set the language to en after installation

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -369,6 +369,7 @@ install_prebuilt = function(
 
 # post-install configurations
 post_install_config = function(add_path, extra_packages, repo, hash = FALSE) {
+  tlmgr(c('conf', 'tlmgr', 'gui-lang', 'en'))
   if (os_index == 2) {
     dir.create('~/bin', FALSE, TRUE)
     tlmgr(c('option', 'sys_bin', '~/bin'))

--- a/tools/install-base.sh
+++ b/tools/install-base.sh
@@ -45,6 +45,7 @@ rm -f install-tl
 alias tlmgr='./bin/*/tlmgr'
 rm -f bin/man bin/*/man
 
+tlmgr conf tlmgr gui-lang en
 tlmgr option repository "$TLREPO"
 
 if [ "$3" != '' ]; then

--- a/tools/install-bin-unix.sh
+++ b/tools/install-bin-unix.sh
@@ -57,6 +57,7 @@ else if [ $TINYTEX_INSTALLER != 'installer-unix' ]; then
 fi
 
 cd $TEXDIR/bin/*/
+./tlmgr conf tlmgr gui-lang en
 [ $OSNAME != "Darwin" ] && ./tlmgr option sys_bin ~/bin
 ([ -z $CI ] || [ $(echo $CI | tr "[:upper:]" "[:lower:]") != "true" ]) && ./tlmgr option repository ctan
 ./tlmgr path add

--- a/tools/install-bin-windows.bat
+++ b/tools/install-bin-windows.bat
@@ -41,6 +41,9 @@ rd /s /q "%APPDATA%\TinyTeX"
 rd /s /q "%APPDATA%\TinyTeX"
 move /y TinyTeX "%APPDATA%"
 
+echo Set language to en
+call "%APPDATA%\TinyTeX\bin\win32\tlmgr" conf tlmgr gui-lang en
+
 echo add tlmgr to PATH
 call "%APPDATA%\TinyTeX\bin\win32\tlmgr" path add
 if /i not "%CI%"=="true" call "%APPDATA%\TinyTeX\bin\win32\tlmgr" option repository ctan


### PR DESCRIPTION
to avoid the message about missing translations (fix #305).