### PR TITLE
remove v from version if passed as in version argument.

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -339,8 +339,8 @@ install_prebuilt = function(
   if (xfun::file_ext(pkg) == '') {
     if (version == 'latest') {
       version = xfun::github_releases('yihui/tinytex-releases', version)
-      version = gsub('^v', '', version)
     }
+    version = gsub('^v', '', version)
     installer = if (pkg == '') 'TinyTeX' else pkg
     # e.g., TinyTeX-0.zip, TinyTeX-1-v2020.10.tar.gz, ...
     pkg = paste0(


### PR DESCRIPTION
This would lead to output of `xfun::github_releases('yihui/tinytex-releases')` working in `install_tinytex()`

This would fix feedback from yihui/tinytex-releases#15 I believe making `tinytex::install_tinytex(version = "v2020.10")` work.