### PR TITLE
quote the `--data` argument for `tl_sizes()`

### DIFF
--- a/R/tlmgr.R
+++ b/R/tlmgr.R
@@ -325,7 +325,7 @@ tl_pkgs = function(only_installed = TRUE) {
 }
 
 tl_list = function(pkgs = NULL, field = 'name', only_installed = TRUE, ...) {
-  tlmgr(c('info', '--list', if (only_installed) '--only-installed', '--data', field, pkgs), ...)
+  tlmgr(c('info', '--list', if (only_installed) '--only-installed', '--data', shQuote(field), pkgs), ...)
 }
 
 tl_platform = function() tlmgr('print-platform', stdout = TRUE, .quiet = TRUE)

--- a/tests/test-travis/test-tlmgr.R
+++ b/tests/test-travis/test-tlmgr.R
@@ -17,6 +17,12 @@ assert('`tlmgr info` can list the installed packages', {
   (c('xetex', 'luatex', 'graphics') %in% res)
 })
 
+assert('`tl_size()` can correctly list name and size', {
+  res = tl_sizes(pkgs = "luatex")$package
+  # only check a few basic packages
+  ('luatex' %==% tl_sizes(pkgs = "luatex")$package)
+})
+
 assert('fonts package are correctly identified', {
   p_q = function(...) parse_packages(..., quiet = c(TRUE, TRUE, TRUE))
   (p_q(text = "! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found") %==% 'symbol')


### PR DESCRIPTION
Fix #329

With this PR, `tl_sizes()` works on WINDOWS

````
> tl_sizes(pkgs = "luatex")
tlmgr info --list --only-installed --data "name,size" luatex
The total size is 148 Kb
  package   size size_h
1  luatex 151552 148 Kb
````

@IndrajeetPatil can you test the PR also ? 

@yihui I added a test ~but not sure they run on Windows anyway. 🤷~ Forget that, We already switched to GHA so it works
