### PR TITLE
Add `SideNotes` package to the maximal TinyTex distribution

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -119,6 +119,7 @@ sectsty
 seqsplit
 setspace
 sidecap
+sidenotes
 siunitx
 soul
 soulutf8


### PR DESCRIPTION
Include the `sidenotes` package in TinyTex. (https://ctan.org/pkg/sidenotes). This package contains useful functionality for placing elements in the margins of documents.

In Quarto, we are using this package when placing figures, captions, references, etc... in the margins (or spanning the body and margin). It would be great if Quarto users weren't required to download this package the first time they compile a document using these features.