### PR TITLE
Handle MikTeX and possibly other distribution in session_info()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,16 +1,19 @@
 # for xfun::session_info('tinytex')
 xfun_session_info = function() {
   pdftex_info = tryCatch(system2('pdflatex', "--version", stdout = TRUE)[1], error = function(e) NULL)
+  if (is.null(pdftex_info)) return(invisible(NULL))
+
   info = if (grepl("TeX Live", pdftex_info, fixed = TRUE)) {
+    # we get more information on tlmgr in that case
     tryCatch(tlmgr_version(raw = FALSE), error = function(e) NULL)
   } else {
-    # e.g MiKTeX-pdfTeX 4.8 (MiKTeX 21.8) return MiKTeX 21.8
+    # For other distributions
+    # e.g MiKTeX-pdfTeX 4.8 (MiKTeX 21.8) returns MiKTeX 21.8
     xfun::grep_sub("^.*\\((.*)\\)$", "\\1", pdftex_info)
   }
 
-  if (length(info)) {
-    return(paste(c("LaTeX version used: ", paste0("  ", info)), collapse = "\n"))
-  }
-  invisible(NULL)
+  if (!length(info)) return(invisible(NULL))
+
+  paste(c("LaTeX version used: ", paste0("  ", info)), collapse = "\n")
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@ xfun_session_info = function() {
 
   info = if (is.null(pdftex_info)) {
     # try tectonic engine ?
-    tryCatch(system2('tectonic', "--version", stdout = TRUE), error = function(e) NULL)
+    tryCatch(system2('tectonic', "--version", stdout = TRUE)[1], error = function(e) NULL)
   } else if (grepl("TeX Live", pdftex_info, fixed = TRUE)) {
     # we get more information on tlmgr in that case
     tryCatch(tlmgr_version(raw = FALSE), error = function(e) NULL)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,10 +1,6 @@
 # for xfun::session_info('tinytex')
 xfun_session_info = function() {
   pdftex_info = tryCatch(system2('pdflatex', "--version", stdout = TRUE)[1], error = function(e) NULL)
-  if (is.null(pdftex_info)) {
-    # try tectonic engine ?
-    tryCatch(system2('tectonic', "--version", stdout = TRUE), error = function(e) NULL)
-  }
 
   info = if (is.null(pdftex_info)) {
     # try tectonic engine ?

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,16 @@
 # for xfun::session_info('tinytex')
 xfun_session_info = function() {
-  tryCatch(tlmgr_version(raw = FALSE), error = function(e) NULL)
+  pdftex_info = tryCatch(system2('pdflatex', "--version", stdout = TRUE)[1], error = function(e) NULL)
+  info = if (grepl("TeX Live", pdftex_info, fixed = TRUE)) {
+    tryCatch(tlmgr_version(raw = FALSE), error = function(e) NULL)
+  } else {
+    # e.g MiKTeX-pdfTeX 4.8 (MiKTeX 21.8) return MiKTeX 21.8
+    xfun::grep_sub("^.*\\((.*)\\)$", "\\1", pdftex_info)
+  }
+
+  if (length(info)) {
+    return(paste(c("LaTeX version used: ", paste0("  ", info)), collapse = "\n"))
+  }
+  invisible(NULL)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,6 +2,7 @@
 xfun_session_info = function() {
   try_null = function(...) tryCatch(..., error = function(e) NULL)
   version_info = function(cmd) try_null(system2(cmd, '--version', stdout = TRUE))
+  tweak_path()
   pdftex_info = version_info('pdflatex')[1]
 
   info = if (is.null(pdftex_info)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,9 +1,15 @@
 # for xfun::session_info('tinytex')
 xfun_session_info = function() {
   pdftex_info = tryCatch(system2('pdflatex', "--version", stdout = TRUE)[1], error = function(e) NULL)
-  if (is.null(pdftex_info)) return(invisible(NULL))
+  if (is.null(pdftex_info)) {
+    # try tectonic engine ?
+    tryCatch(system2('tectonic', "--version", stdout = TRUE), error = function(e) NULL)
+  }
 
-  info = if (grepl("TeX Live", pdftex_info, fixed = TRUE)) {
+  info = if (is.null(pdftex_info)) {
+    # try tectonic engine ?
+    tryCatch(system2('tectonic', "--version", stdout = TRUE), error = function(e) NULL)
+  } else if (grepl("TeX Live", pdftex_info, fixed = TRUE)) {
     # we get more information on tlmgr in that case
     tryCatch(tlmgr_version(raw = FALSE), error = function(e) NULL)
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,21 +1,20 @@
 # for xfun::session_info('tinytex')
 xfun_session_info = function() {
-  pdftex_info = tryCatch(system2('pdflatex', "--version", stdout = TRUE)[1], error = function(e) NULL)
+  try_null = function(...) tryCatch(..., error = function(e) NULL)
+  version_info = function(cmd) try_null(system2(cmd, '--version', stdout = TRUE))
+  pdftex_info = version_info('pdflatex')[1]
 
   info = if (is.null(pdftex_info)) {
-    # try tectonic engine ?
-    tryCatch(system2('tectonic', "--version", stdout = TRUE)[1], error = function(e) NULL)
-  } else if (grepl("TeX Live", pdftex_info, fixed = TRUE)) {
+    version_info('tectonic')[1]  # try tectonic engine?
+  } else if (grepl('TeX Live', pdftex_info, fixed = TRUE)) {
     # we get more information on tlmgr in that case
-    tryCatch(tlmgr_version(raw = FALSE), error = function(e) NULL)
+    try_null(tlmgr_version(raw = FALSE))
   } else {
-    # For other distributions
-    # e.g MiKTeX-pdfTeX 4.8 (MiKTeX 21.8) returns MiKTeX 21.8
-    xfun::grep_sub("^.*\\((.*)\\)$", "\\1", pdftex_info)
+    # for other distributions, e.g., MiKTeX-pdfTeX 4.8 (MiKTeX 21.8)
+    xfun::grep_sub('^.*\\((.*)\\)$', '\\1', pdftex_info)
   }
-
   if (!length(info)) return(invisible(NULL))
 
-  paste(c("LaTeX version used: ", paste0("  ", info)), collapse = "\n")
+  paste(c('LaTeX version used: ', paste0('  ', info)), collapse = '\n')
 }
 


### PR DESCRIPTION
Close #342 

When using TeX Live (with TinyTeX or not)

````
> xfun::session_info("tinytex")
R version 4.1.1 (2021-08-10)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19043), RStudio 2022.1.0.247

Locale:
  LC_COLLATE=French_France.1252  LC_CTYPE=French_France.1252   
  LC_MONETARY=French_France.1252 LC_NUMERIC=C                  
  LC_TIME=French_France.1252    
system code page: 65001

Package version:
  graphics_4.1.1  grDevices_4.1.1 stats_4.1.1     tinytex_0.35.3  tools_4.1.1    
  utils_4.1.1     xfun_0.28.6    

LaTeX version used: 
  TeX Live 2021 (TinyTeX) with tlmgr 2021-10-04
````

When using MikTeX: 

````
> xfun::session_info("tinytex")
R version 4.1.1 (2021-08-10)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19043), RStudio 2022.1.0.247

Locale:
  LC_COLLATE=French_France.1252  LC_CTYPE=French_France.1252   
  LC_MONETARY=French_France.1252 LC_NUMERIC=C                  
  LC_TIME=French_France.1252    
system code page: 65001

Package version:
  graphics_4.1.1  grDevices_4.1.1 stats_4.1.1     tinytex_0.35.3  tools_4.1.1    
  utils_4.1.1     xfun_0.28.6    

LaTeX version used: 
  MiKTeX 21.8
````

As you can see I added `LaTeX version used: ` to correctly categorize in the `xfun::session_info()` output. 

Also I did not make a specific case for MikTeX only as I guess all other distribution will output something in parenthesis hopefully.
We could also not parse the line when not TeX Live and return the 1st line result of `pdflatex --version` as raw string 🤔 
Maybe the safest....
It would be
```
MiKTeX-pdfTeX 4.8 (MiKTeX 21.8)
````
And the result for `tlmgr_version(raw = FALSE)` when we detect TeX Live ?