### PR TITLE
Add subcaption package to pkgs-yihui.txt

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -129,6 +129,7 @@ standalone
 stix
 stmaryrd
 sttools
+subcaption
 subfig
 subfigure
 symbol


### PR DESCRIPTION
We are now using the `subcaption` package in Quarto to enable positioning sub-captions above or below figures/tables based on user preference. It would be great if this were pre-installed as part of the standard pkgs-yihui suite.