### PR TITLE
ametsoc is now obsolete on CTAN

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -4,7 +4,6 @@ adjustbox
 ae
 algorithmicx
 algorithms
-ametsoc
 amscls
 apacite
 appendix


### PR DESCRIPTION
This was reported in https://community.rstudio.com/t/package-ametsoc-not-present-in-repository/134052
Also we can confirm in our builds: https://github.com/yihui/tinytex/runs/5966157110?check_suite_focus=true#step:10:66

Package is obsolete on CTAN: https://www.ctan.org/pkg/ametsoc

We should probably remove it from our list ? How do you usually deal with this ?