### PR TITLE
Building daily full bundle TinyTeX-2 on GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,7 +243,7 @@ jobs:
     steps:
       - name: Create release note
         run: |
-          echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > notes.md
+          echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r %Z'))." > notes.md
           echo "Please see https://github.com/yihui/tinytex-releases for more info." >> notes.md
 
       - name: Update GH to get 2.8 needed for gh release edit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,16 +28,12 @@ jobs:
         run: |
           git tag pre-daily
           git push --tags
-      - name: Create release note
-        run: |
-          echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > .github/notes.md
-          echo "Please see https://github.com/yihui/tinytex-releases for more info." >> .github/notes.md
 
       - name: Create new draft release
         id: draft
         run: |
           tag=daily
-          url=$(gh -R cderv/tinytex-releases release create ${tag} --draft --prerelease --title "TinyTeX daily build" --notes-file ".github/notes.md")
+          url=$(gh -R cderv/tinytex-releases release create ${tag} --draft --prerelease --title "TinyTeX daily build" --notes "(WIP) Next daily release")
           echo "::set-output name=draft-tag::$(echo $url | grep -o tag/[^/]*$ | cut -c 5-)"
           echo "::set-output name=tag::${tag}"
     
@@ -253,8 +249,12 @@ jobs:
     needs: [new-release, build-windows, build-linux, build-mac]
     runs-on: ubuntu-latest
     name: Publish new daily release
-    
+
     steps:
+      - name: Create release note
+        run: |
+          echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > .github/notes.md
+          echo "Please see https://github.com/yihui/tinytex-releases for more info." >> .github/notes.md
       - name: Publish new release
         env:
           GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
@@ -266,6 +266,6 @@ jobs:
           echo -e "\n::endgroup::"
           echo "::group::undraft new and delete current release"
           old=$(gh release edit ${{needs.new-release.outputs.tag}} --draft=true | grep -o tag/[^/]*$ | cut -c 5-)
-          gh release edit ${{needs.new-release.outputs.draft}} --draft=false
+          gh release edit ${{needs.new-release.outputs.draft}} --draft=false --notes-file .github/notes.md
           gh release delete ${old} -y
           echo -e "\n::endgroup::"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,6 @@ jobs:
           r-version: release
           use-public-rspm: true
 
-      # do we want to install CRAN tinytex or dev tinytex ?
       - name: Install tinytex package and its deps
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -184,6 +183,8 @@ jobs:
       - run: ls -lisa
 
       - name: Upload bundles
+        # this specific action is used at some issues have been observe with gh while uploading assets
+        # This allows to not fail the workflow on upload, but retry a few time
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 5
@@ -276,6 +277,7 @@ jobs:
           echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r %Z'))." > notes.md
           echo "Please see https://github.com/yihui/tinytex-releases for more info." >> notes.md
 
+      # TODO: Remove when version 2.8 will be available on GHA
       - name: Update GH to get 2.8 needed for gh release edit
         run: |
           gh release download -R cli/cli --pattern '*linux_amd64.deb'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,11 +27,6 @@ jobs:
           echo "::set-output name=draft-tag::$(echo $url | grep -o tag/[^/]*$ | cut -c 5-)"
           echo "::set-output name=tag::${tag}"
 
-      - name: Update GH to get 2.8 needed for gh release edit
-        run: |
-          gh release download -R cli/cli --pattern '*linux_amd64.deb'
-          sudo dpkg -i $(ls *.deb)
-    
   build-windows:
     needs: [new-release]
     runs-on: windows-latest
@@ -43,7 +38,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Pandoc
         uses: r-lib/actions/setup-pandoc@v2
@@ -250,6 +245,12 @@ jobs:
         run: |
           echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > notes.md
           echo "Please see https://github.com/yihui/tinytex-releases for more info." >> notes.md
+
+      - name: Update GH to get 2.8 needed for gh release edit
+        run: |
+          gh release download -R cli/cli --pattern '*linux_amd64.deb'
+          sudo dpkg -i $(ls *.deb)
+          
       - name: Publish new release
         run: |
           echo "::group::Move tag to last commit on master"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build TinyTeX-2 (scheme-full)
         run: |
-          RScript "tools/build-scheme-full.R"
+          Rscript "tools/build-scheme-full.R"
           Compress-Archive $Env:APPDATA\\TinyTeX TinyTeX-2.zip
 
       - name: Test Installation
@@ -153,7 +153,7 @@ jobs:
 
       - name: Build TinyTeX-2 (scheme-full)
         run: |
-          RScript "tools/build-scheme-full.R"
+          Rscript "tools/build-scheme-full.R"
           tar zcf TinyTeX-2.tar.gz -C ~ .TinyTeX
 
       - name: Export Regex file
@@ -233,7 +233,7 @@ jobs:
 
       - name: Build TinyTeX-2 (scheme-full)
         run: |
-          RScript "tools/build-scheme-full.R"
+          Rscript "tools/build-scheme-full.R"
           tar zcf TinyTeX-2.tgz -C ~/Library TinyTeX
 
       - name: Test Installation

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,16 +19,6 @@ jobs:
       draft-tag: ${{ steps.draft.outputs.draft-tag }}
 
     steps:
-      - name: Configure Git
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-
-      - name: Create temp tag
-        run: |
-          git tag pre-daily
-          git push --tags
-
       - name: Create new draft release
         id: draft
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,8 +243,8 @@ jobs:
     steps:
       - name: Create release note
         run: |
-          echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > .github/notes.md
-          echo "Please see https://github.com/yihui/tinytex-releases for more info." >> .github/notes.md
+          echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > notes.md
+          echo "Please see https://github.com/yihui/tinytex-releases for more info." >> notes.md
       - name: Publish new release
         run: |
           echo "::group::Move tag to last commit on master"
@@ -253,7 +253,7 @@ jobs:
           echo -e "\n::endgroup::"
           echo "::group::undraft new and delete current release"
           old=$(gh release edit ${{needs.new-release.outputs.tag}} --draft=true | grep -o tag/[^/]*$ | cut -c 5-)
-          gh release edit ${{needs.new-release.outputs.draft-tag}} --draft=false --notes-file .github/notes.md
+          gh release edit ${{needs.new-release.outputs.draft-tag}} --draft=false --notes-file notes.md
           gh release delete ${old} -y
           echo -e "\n::endgroup::"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip tinytex.zip
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip tinytex.zip
 
   build-linux:
     needs: [new-release]
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinytex.tar.gz installer-unix.tar.gz regex.tar.gz
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinytex.tar.gz installer-unix.tar.gz regex.tar.gz
 
   build-mac:
     needs: [new-release]
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz tinytex.tgz
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz tinytex.tgz
 
   deploy:
     needs: [new-release, build-windows, build-linux, build-mac]
@@ -256,6 +256,6 @@ jobs:
           echo -e "\n::endgroup::"
           echo "::group::undraft new and delete current release"
           old=$(gh release edit ${{needs.new-release.outputs.tag}} --draft=true | grep -o tag/[^/]*$ | cut -c 5-)
-          gh release edit ${{needs.new-release.outputs.draft}} --draft=false --notes-file .github/notes.md
+          gh release edit ${{needs.new-release.outputs.draft-tag}} --draft=false --notes-file .github/notes.md
           gh release delete ${old} -y
           echo -e "\n::endgroup::"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -258,7 +258,7 @@ jobs:
           echo -e "\n::endgroup::"
 
   cleaning:
-    needs: [new-release, build-windows, build-linux, build-mac]
+    needs: [new-release, deploy]
     if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-latest
     name: Cleaning step in case of error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinytex.zip installer-unix.tar.gz regex.tar.gz
+          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinytex.tar.gz installer-unix.tar.gz regex.tar.gz
 
   build-mac:
     needs: [new-release]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,11 @@ jobs:
           url=$(gh -R cderv/tinytex-releases release create ${tag} --draft --prerelease --title "TinyTeX daily build" --notes "(WIP) Next daily release")
           echo "::set-output name=draft-tag::$(echo $url | grep -o tag/[^/]*$ | cut -c 5-)"
           echo "::set-output name=tag::${tag}"
+
+      - name: Update GH to get 2.8 needed for gh release edit
+        run: |
+          gh release download -R cli/cli --pattern '*linux_amd64.deb'
+          sudo dpkg -i $(ls *.deb)
     
   build-windows:
     needs: [new-release]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -246,9 +246,6 @@ jobs:
           echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > .github/notes.md
           echo "Please see https://github.com/yihui/tinytex-releases for more info." >> .github/notes.md
       - name: Publish new release
-        env:
-          GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          GH_REPO: cderv/tinytex-releases
         run: |
           echo "::group::Move tag to last commit on master"
           sha=$(gh api repos/{owner}/{repo}/git/ref/heads/master --jq '.object.sha')
@@ -259,3 +256,13 @@ jobs:
           gh release edit ${{needs.new-release.outputs.draft-tag}} --draft=false --notes-file .github/notes.md
           gh release delete ${old} -y
           echo -e "\n::endgroup::"
+
+  cleaning:
+    needs: [new-release, build-windows, build-linux, build-mac]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    name: Cleaning step in case of error
+    steps:
+      - name: Remove unused daily release
+        run: |
+          gh release delete ${{needs.new-release.outputs.draft-tag}} -y

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,8 +99,13 @@ jobs:
       - run: dir .
 
       - name: Upload bundles
-        run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip TinyTeX-2.zip tinitex.zip --clobber
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: |
+            gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip TinyTeX-2.zip tinitex.zip --clobber
 
   build-linux:
     needs: [new-release]
@@ -179,8 +184,13 @@ jobs:
       - run: ls -lisa
 
       - name: Upload bundles
-        run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz TinyTeX-2.tar.gz tinitex.tar.gz installer-unix.tar.gz regex.tar.gz --clobber
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: |
+            gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz TinyTeX-2.tar.gz tinitex.tar.gz installer-unix.tar.gz regex.tar.gz --clobber
 
   build-mac:
     needs: [new-release]
@@ -247,8 +257,13 @@ jobs:
       - run: ls -lisa
 
       - name: Upload bundles
-        run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz TinyTeX-2.tgz tinitex.tgz --clobber
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: |
+            gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz TinyTeX-2.tgz tinitex.tgz --clobber
 
   deploy:
     needs: [new-release, build-windows, build-linux, build-mac]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,12 +1,48 @@
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '5 4 * * *'
+  #schedule:
+  #  - cron: '5 4 * * *'
 
 name: Build TinyTeX Bundles
 
+env:
+  # for gh usage with external repo
+  GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+  GH_REPO: cderv/tinytex-releases
+
 jobs:
+  new-release:
+    runs-on: ubuntu-latest
+    name: Create new daily draft release
+    outputs:
+      tag: ${{ steps.draft.outputs.tag }}
+      draft-tag: ${{ steps.draft.outputs.draft-tag }}
+
+    steps:
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Create temp tag
+        run: |
+          git tag pre-daily
+          git push --tags
+      - name: Create release note
+        run: |
+          echo "This release contains the daily build of TinyTeX ($(date +'%A %B %d %Y %r'))." > .github/notes.md
+          echo "Please see https://github.com/yihui/tinytex-releases for more info." >> .github/notes.md
+
+      - name: Create new draft release
+        id: draft
+        run: |
+          tag=daily
+          url=$(gh -R cderv/tinytex-releases release create ${tag} --draft --prerelease --title "TinyTeX daily build" --notes-file ".github/notes.md")
+          echo "::set-output name=draft-tag::$(echo $url | grep -o tag/[^/]*$ | cut -c 5-)"
+          echo "::set-output name=tag::${tag}"
+    
   build-windows:
+    needs: [new-release]
     runs-on: windows-latest
     name: Build Bundles For Windows
 
@@ -72,16 +108,11 @@ jobs:
       - run: dir .
 
       - name: Upload bundles
-        uses: actions/upload-artifact@v3
-        with:
-          name: bundles
-          path: |
-            TinyTeX*.zip
-            tinitex.zip
-          if-no-files-found: error
-          retention-days: 1
+        run: |
+          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip tinytex.zip
 
   build-linux:
+    needs: [new-release]
     runs-on: ubuntu-latest
     name: Build Bundles For Linux
 
@@ -152,18 +183,11 @@ jobs:
       - run: ls -lisa
 
       - name: Upload bundles
-        uses: actions/upload-artifact@v3
-        with:
-          name: bundles
-          path: |
-            TinyTeX*.tar.gz
-            tinitex.tar.gz
-            installer-unix.tar.gz
-            regex.tar.gz
-          if-no-files-found: error
-          retention-days: 1
+        run: |
+          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinytex.zip installer-unix.tar.gz regex.tar.gz
 
   build-mac:
+    needs: [new-release]
     runs-on: macos-latest
     name: Build Bundles For macOS
 
@@ -222,58 +246,26 @@ jobs:
       - run: ls -lisa
 
       - name: Upload bundles
-        uses: actions/upload-artifact@v3
-        with:
-          name: bundles
-          path: |
-            TinyTeX*.tgz
-            tinitex.tgz
-          if-no-files-found: error
-          retention-days: 1
+        run: |
+          gh release upload ${{needs.new-release.outputs.draft}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz tinytex.tgz
 
   deploy:
-    needs: [build-windows, build-linux, build-mac]
+    needs: [new-release, build-windows, build-linux, build-mac]
     runs-on: ubuntu-latest
-    name: deploy artifacts as Github release
-
+    name: Publish new daily release
+    
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: bundles
-          path: ${{ runner.temp }}/tinytex-bundles
-
-      - run: ls -lisa tinytex-bundles
-        working-directory: ${{ runner.temp }}
-
-      - name: Get Date for bundles
-        run: echo "CURRENT_DATE=($(date +'%A %B %d %Y %r'))" >> $GITHUB_ENV
-
-      - name: Create draft release with new assets
-        id: draft-release
-        uses: softprops/action-gh-release@v1
-        with:
-          repository: yihui/tinytex-releases
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          draft: true
-          prerelease: true
-          name: TinyTeX daily build
-          body: |
-            This release contains the daily build of TinyTeX${{ env.CURRENT_DATE }}.
-            Please see https://github.com/yihui/tinytex-releases for more info.
-          files: ${{ runner.temp }}/tinytex-bundles/*
-          fail_on_unmatched_files: true
-          generate_release_notes: false
-
       - name: Publish new release
         env:
           GH_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          GH_REPO: yihui/tinytex-releases
+          GH_REPO: cderv/tinytex-releases
         run: |
           echo "::group::Move tag to last commit on master"
           sha=$(gh api repos/{owner}/{repo}/git/ref/heads/master --jq '.object.sha')
           gh api repos/{owner}/{repo}/git/refs/tags/daily -f sha=$sha --template 'Tag {{.ref | color "blue"}} moved on commit sha {{.object.sha | color "blue"}}.'
           echo -e "\n::endgroup::"
-          echo "::group::delete current release and undraft new"
-          gh release delete daily -y
-          gh api repos/{owner}/{repo}/releases/${{ steps.draft-release.outputs.id}} -f draft=false -f tag_name='daily' --template 'Release url: {{.html_url}}'
+          echo "::group::undraft new and delete current release"
+          old=$(gh release edit ${{needs.new-release.outputs.tag}} --draft=true | grep -o tag/[^/]*$ | cut -c 5-)
+          gh release edit ${{needs.new-release.outputs.draft}} --draft=false
+          gh release delete ${old} -y
           echo -e "\n::endgroup::"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip tinytex.zip
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip tinitex.zip --clobber
 
   build-linux:
     needs: [new-release]
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinytex.tar.gz installer-unix.tar.gz regex.tar.gz
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinitex.tar.gz installer-unix.tar.gz regex.tar.gz --clobber
 
   build-mac:
     needs: [new-release]
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz tinytex.tgz
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz tinitex.tgz --clobber
 
   deploy:
     needs: [new-release, build-windows, build-linux, build-mac]
@@ -259,7 +259,7 @@ jobs:
 
   cleaning:
     needs: [new-release, build-windows, build-linux, build-mac]
-    if: ${{ failure() }}
+    if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-latest
     name: Cleaning step in case of error
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,6 +82,11 @@ jobs:
           Rscript "tools/test-basic.R"  # even more LaTeX packages
           Compress-Archive $Env:APPDATA\\TinyTeX TinyTeX.zip
 
+      - name: Build TinyTeX-2 (scheme-full)
+        run: |
+          RScript "tools/build-scheme-full.R"
+          Compress-Archive $Env:APPDATA\\TinyTeX TinyTeX-2.zip
+
       - name: Test Installation
         env:
           TINYTEX_INSTALLER: TinyTeX-0
@@ -95,7 +100,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip tinitex.zip --clobber
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.zip TinyTeX-1.zip TinyTeX.zip TinyTeX-2.zip tinitex.zip --clobber
 
   build-linux:
     needs: [new-release]
@@ -146,6 +151,11 @@ jobs:
           Rscript "tools/test-basic.R"
           tar zcf TinyTeX.tar.gz -C ~ .TinyTeX
 
+      - name: Build TinyTeX-2 (scheme-full)
+        run: |
+          RScript "tools/build-scheme-full.R"
+          tar zcf TinyTeX-2.tar.gz -C ~ .TinyTeX
+
       - name: Export Regex file
         run: |
           Rscript "tools/export-regex.R"
@@ -170,7 +180,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz tinitex.tar.gz installer-unix.tar.gz regex.tar.gz --clobber
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tar.gz TinyTeX-1.tar.gz TinyTeX.tar.gz TinyTeX-2.tar.gz tinitex.tar.gz installer-unix.tar.gz regex.tar.gz --clobber
 
   build-mac:
     needs: [new-release]
@@ -221,6 +231,11 @@ jobs:
           Rscript "tools/test-basic.R"
           tar zcf TinyTeX.tgz -C ~/Library TinyTeX
 
+      - name: Build TinyTeX-2 (scheme-full)
+        run: |
+          RScript "tools/build-scheme-full.R"
+          tar zcf TinyTeX-2.tgz -C ~/Library TinyTeX
+
       - name: Test Installation
         env:
           TINYTEX_INSTALLER: TinyTeX-0
@@ -233,7 +248,7 @@ jobs:
 
       - name: Upload bundles
         run: |
-          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz tinitex.tgz --clobber
+          gh release upload ${{needs.new-release.outputs.draft-tag}} TinyTeX-0.tgz TinyTeX-1.tgz TinyTeX.tgz TinyTeX-2.tgz tinitex.tgz --clobber
 
   deploy:
     needs: [new-release, build-windows, build-linux, build-mac]
@@ -250,7 +265,7 @@ jobs:
         run: |
           gh release download -R cli/cli --pattern '*linux_amd64.deb'
           sudo dpkg -i $(ls *.deb)
-          
+
       - name: Publish new release
         run: |
           echo "::group::Move tag to last commit on master"

--- a/tools/build-scheme-full.R
+++ b/tools/build-scheme-full.R
@@ -1,0 +1,2 @@
+tinytex::tlmgr_install('scheme-full')
+sys.source('tools/clean-tlpdb.R')


### PR DESCRIPTION
This adapt the current daily build workflow so that we are building the full version in the same workflow here and not in yihui/tinytex-releases anymore. 

This is part of the work to migrate from Appveyor (https://github.com/yihui/tinytex-releases/pull/22). 

Monthly release and chocolatey packaging are still done in tinytex-releases repo.

This will increase the build time of the daily release to 1 or 2hours, but that is reasonable. 

We are also using new version for `gh` CLI which allow us to undraft a draft release. New workflow is now

* Create a new draft release for the daily release. Currently daily will still be available at https://github.com/yihui/tinytex-releases/releases/tag/daily
* We build in parallel all the bundle for Linux, Mac and Windows and upload assets in the draft release at the end of each OS build step
* If everything went right, then we are making the currently daily a draft, then undrafting the prepared draft for new daily which contains new assets, and updating the release note, then deleting the previous daily release. 
Doing the drafting part before deleting will allow us to undraft manually, if there is an issue in the process of undrafting. 

It is working ok in my fork (https://github.com/cderv/tinytex/actions/runs/2208840019) - Total time is 1H for the all workflow. 

Is there anything that question you ? Does it seems ok to you ? 
