### PR TITLE
Fix font package detection for fonts with spaces in names

### DIFF
--- a/R/latex.R
+++ b/R/latex.R
@@ -662,6 +662,7 @@ miss_font = function() {
 
 font_ext = function(x) {
   i = !grepl('[.]', x)
+  x[i] = gsub('\\s+', '\\\\s*', x[i])  # Replace spaces with \s*
   x[i] = paste0(x[i], '(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)')
   x
 }

--- a/tests/test-cran/test-latex.R
+++ b/tests/test-cran/test-latex.R
@@ -1,5 +1,13 @@
 library(testit)
 
+assert('font_ext() handles spaces in font names correctly', {
+  # Issue #478: font names with spaces should have spaces replaced with \s*
+  (font_ext("Noto Emoji") %==% 'Noto\\s*Emoji(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)')
+  (font_ext("DejaVu Sans") %==% 'DejaVu\\s*Sans(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)')
+  # Font names without spaces should work as before
+  (font_ext("FandolSong-Regular") %==% 'FandolSong-Regular(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)')
+})
+
 assert('detect_files() can detect filenames from LaTeX log', {
   # Fonts are also tested in test-tlmgr.R
   (detect_files("! Font U/psy/m/n/10=psyr at 10.0pt not loadable: Metric (TFM) file not found") %==% font_ext("psyr"))
@@ -7,6 +15,9 @@ assert('detect_files() can detect filenames from LaTeX log', {
   (detect_files('!pdfTeX error: /usr/local/bin/pdflatex (file tcrm0700): Font tcrm0700 at 600 not found') %==% font_ext('tcrm0700'))
   (detect_files('(fontspec)                The font "LibertinusSerif-Regular" cannot be') %==% font_ext('LibertinusSerif-Regular'))
   (detect_files('! Font \\JY3/mc/m/n/10=file:HaranoAjiMincho-Regular.otf:-kern;jfm=ujis at 9.24713pt not loadable: metric data not found or bad.') %==% 'HaranoAjiMincho-Regular.otf')
+  # Fonts with spaces in names (issue #478)
+  (detect_files('! The font "Noto Emoji" cannot be found.') %==% font_ext("Noto Emoji"))
+  (detect_files('! The font "DejaVu Sans" cannot be found.') %==% font_ext("DejaVu Sans"))
 
   (length(detect_files("asdf qwer")) == 0)
   (detect_files("! LaTeX Error: File `framed.sty' not found.") %==% 'framed.sty')


### PR DESCRIPTION
When R Markdown documents use fonts with spaces in their names (e.g., "Noto Emoji", "DejaVu Sans"), automatic package installation via `tinytex::parse_install()` fails because `tlmgr search` cannot find the packages.

## Root Cause

The `font_ext()` function generates search patterns that preserve spaces from the font name reported in LaTeX errors. When LaTeX reports "Font 'Noto Emoji' not found", the generated pattern is:

```
Noto Emoji(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)
```

Font files never have spaces in their names (`NotoEmoji-Regular.ttf`, `DejaVuSans-Bold.ttf`), so `tlmgr search --file` fails to find matching packages.

## Fix

Spaces in font names are replaced with `\s*` regex pattern in `R/latex.R:665`:

```r
x[i] = gsub('\s+', '\\s*', x[i])
```

This generates patterns like `Noto\s*Emoji(-(Bold|Italic|Regular).*)?[.](tfm|afm|mf|otf|ttf)` that match actual font files.

Tests were added in `tests/test-cran/test-latex.R` to verify both the `font_ext()` function directly and the full `detect_files()` workflow for fonts with spaces.

Fixes #478