### PR TITLE
Remove l3backend. It's now integrated in l3kernel.

### DIFF
--- a/tools/pkgs-custom.txt
+++ b/tools/pkgs-custom.txt
@@ -46,7 +46,6 @@ knuth-lib
 kvdefinekeys
 kvoptions
 kvsetkeys
-l3backend
 l3kernel
 l3packages
 latex


### PR DESCRIPTION
- https://www.mail-archive.com/ctan-ann@ctan.org/msg13747.html
- Resolves https://github.com/rstudio/tinytex/issues/513